### PR TITLE
refactor(performance): detect gzip presence once, jittable find

### DIFF
--- a/kong/plugins/inflate-gzip/handler.lua
+++ b/kong/plugins/inflate-gzip/handler.lua
@@ -1,14 +1,28 @@
 local string_find = string.find
 
+
+-- resolve version incompatibility between Kong 3.5- and 3.6+
+local deflate_gzip, inflate_gzip do
+  local ok, utils = pcall(require, "kong.tools.gzip") -- Kong 3.6 and beyond
+  if not ok then
+    utils = require("kong.tools.utils") -- Kong 3.5 and before
+  end
+
+  deflate_gzip = utils.deflate_gzip
+  inflate_gzip = utils.inflate_gzip
+end
+
+
 local plugin = {
   PRIORITY = 2000,
   VERSION = "1.0",
 }
 
+
 function plugin:header_filter(conf)
   local c_encoding = kong.request.get_header("Content-Encoding")
 
-  if conf.deflate_response and (not c_encoding or (not string_find(c_encoding, "gzip"))) then
+  if conf.deflate_response and (not c_encoding or (not string_find(c_encoding, "gzip", 1, true))) then
     kong.log.debug("will deflate response body - clearing headers")
 
     kong.response.set_header("Content-Encoding", "gzip")
@@ -20,19 +34,13 @@ end
 function plugin:body_filter(conf)
   -- check that it isn't already gzip'd
   local c_encoding = kong.request.get_header("Content-Encoding")
-  if conf.deflate_response and (not c_encoding or (not string_find(c_encoding, "gzip"))) then
+  if conf.deflate_response and (not c_encoding or (not string_find(c_encoding, "gzip", 1, true))) then
     kong.log.debug("deflating response")
-
-    local is_36, utils = pcall(require, "kong.tools.gzip")
-    if not is_36 then
-      kong.log.debug("Kong <=3.5 detected, kong.tools.utils is loaded instead")
-      utils = require("kong.tools.utils")
-    end
 
     local response_body = kong.response.get_raw_body()
 
     if response_body then
-      kong.response.set_raw_body(utils.deflate_gzip(response_body))
+      kong.response.set_raw_body(deflate_gzip(response_body))
 
       kong.log.debug("plaintext response body deflated and replaced")
     else
@@ -47,19 +55,13 @@ end
 function plugin:access(conf)
   local c_encoding = kong.request.get_header("Content-Encoding")
 
-  if c_encoding and string_find(c_encoding, "gzip") then
+  if c_encoding and string_find(c_encoding, "gzip", 1, true) then
     kong.log.debug("body is gzip'd")
-
-    local is_36, utils = pcall(require, "kong.tools.gzip")
-    if not is_36 then
-      kong.log.debug("Kong <=3.5 detected, kong.tools.utils is loaded instead")
-      utils = require("kong.tools.utils")
-    end
 
     local request_body = kong.request.get_raw_body()
 
     if request_body then
-      kong.service.request.set_raw_body(utils.inflate_gzip(request_body))
+      kong.service.request.set_raw_body(inflate_gzip(request_body))
       kong.service.request.clear_header("Content-Encoding")
 
       kong.log.debug("gzip'd request body inflated and replaced")


### PR DESCRIPTION
Loading the module and detecting where to find gzip can be done once at system start, since it is not going to change while the system is running.

string.find is jittable only if seraching without patterns (which is the case, so we enable that).